### PR TITLE
fix spl2022 transfer

### DIFF
--- a/txn/solana/spl2022.go
+++ b/txn/solana/spl2022.go
@@ -50,8 +50,8 @@ func (spl2022 *Spl2022TransferInstruction) Data() ([]byte, error) {
 	return spl2022.splTransferInstruction.Data()
 }
 
-func NewSpl2022TransferInstruction(amount uint64, source solana.PublicKey, destination solana.PublicKey, owner solana.PublicKey) *Spl2022CreateAtaInstruction {
-	return &Spl2022CreateAtaInstruction{
-		splCreateAtaInstruction: solana_token.NewTransferInstruction(amount, source, destination, owner, []solana.PublicKey{}).Build(),
+func NewSpl2022TransferInstruction(amount uint64, source solana.PublicKey, destination solana.PublicKey, owner solana.PublicKey) *Spl2022TransferInstruction {
+	return &Spl2022TransferInstruction{
+		splTransferInstruction: solana_token.NewTransferInstruction(amount, source, destination, owner, []solana.PublicKey{}).Build(),
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `NewSpl2022TransferInstruction` method signature to return the correct transfer instruction type.
	- Adjusted internal instruction type to align with the transfer instruction structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->